### PR TITLE
Typecast with TYPENAME before va_args to avoid unpredictable results

### DIFF
--- a/lib/C/iec_std_functions.h
+++ b/lib/C/iec_std_functions.h
@@ -500,7 +500,7 @@ static inline TYPENAME fname(EN_ENO_PARAMS UINT param_count, TYPENAME op1, ...){
   va_start (ap, op1);         /* Initialize the argument list.  */\
   \
   for (i = 0; i < param_count - 1; i++){\
-    op1 = op1 OP va_arg (ap, VA_ARGS_##TYPENAME);\
+    op1 = op1 OP (TYPENAME)va_arg (ap, VA_ARGS_##TYPENAME);\
   }\
   \
   va_end (ap);                  /* Clean up.  */\


### PR DESCRIPTION
Some compilers, like avr-gcc, will get mad when you do arithmetic operations with operands from different data types. For example, compiling this function on avr-gcc will make OR__BOOL__BOOL((BOOL)__BOOL_LITERAL(TRUE), NULL, (UINT)2, (BOOL)0, (BOOL)0) return 1 instead of 0. By adding a typecast of the variable type before va_arg, the arithmetic function returns the correct value. This has no change on platforms that already worked correctly.