### PR TITLE
Fix array initialization handling in stage3 and C codegen

### DIFF
--- a/stage3/array_range_check.cc
+++ b/stage3/array_range_check.cc
@@ -105,6 +105,52 @@ int array_range_check_c::get_error_count() {
 }
 
 
+unsigned long long int array_range_check_c::array_size(symbol_c *symbol) {
+	unsigned long long int size = 1;
+	array_dimension_iterator_c array_dimension_iterator(symbol);
+
+	for (subrange_c *dimension = array_dimension_iterator.next(); dimension != NULL; dimension = array_dimension_iterator.next()) {
+		if ((dimension->dimension != 0) && (size > (std::numeric_limits<unsigned long long int>::max() / dimension->dimension)))
+			return std::numeric_limits<unsigned long long int>::max();
+		size *= dimension->dimension;
+	}
+
+	return size;
+}
+
+
+unsigned long long int array_range_check_c::initialization_element_count(symbol_c *symbol) {
+	if (symbol == NULL)
+		return 0;
+
+	array_initial_elements_list_c *list = dynamic_cast<array_initial_elements_list_c *>(symbol);
+	if (list != NULL) {
+		unsigned long long int total = 0;
+		for (int i = 0; i < list->n; i++) {
+			unsigned long long int elem_count = initialization_element_count(list->get_element(i));
+			if (total > (std::numeric_limits<unsigned long long int>::max() - elem_count))
+				return std::numeric_limits<unsigned long long int>::max();
+			total += elem_count;
+		}
+		return total;
+	}
+
+	array_initial_elements_c *repeated = dynamic_cast<array_initial_elements_c *>(symbol);
+	if (repeated != NULL) {
+		if (VALID_CVALUE( int64, repeated->integer)) {
+			if (GET_CVALUE( int64, repeated->integer) < 0)
+				ERROR; /* the IEC 61131-3 syntax guarantees that this value will never be negative! */
+			return GET_CVALUE( int64, repeated->integer);
+		}
+		if (VALID_CVALUE(uint64, repeated->integer))
+			return GET_CVALUE(uint64, repeated->integer);
+		ERROR;
+	}
+
+	return 1;
+}
+
+
 
 void array_range_check_c::check_dimension_count(array_variable_c *symbol) {
 	int dimension_count;
@@ -187,6 +233,31 @@ void array_range_check_c::check_bounds(array_variable_c *symbol) {
 /* B 1.3.3 - Derived data types */
 /********************************/
 
+/* array_specification [ASSIGN array_initialization] */
+/* array_initialization may be NULL ! */
+// SYM_REF2(array_spec_init_c, array_specification, array_initialization)
+void *array_range_check_c::visit(array_spec_init_c *symbol) {
+	symbol->array_specification->accept(*this);
+
+	if (symbol->array_initialization != NULL) {
+		unsigned long long int size = array_size(symbol->array_specification);
+		unsigned long long int count = initialization_element_count(symbol->array_initialization);
+		if (count > size)
+			STAGE3_ERROR(0, symbol->array_initialization, symbol->array_initialization,
+			             "Array initialization exceeds the array size declared in its type.");
+	}
+
+	return NULL;
+}
+
+/* array_initialization:  '[' array_initial_elements_list ']' */
+/* helper symbol for array_initialization */
+/* array_initial_elements_list ',' array_initial_elements */
+// SYM_LIST(array_initial_elements_list_c)
+void *array_range_check_c::visit(array_initial_elements_list_c *symbol) {
+	return iterator_visitor_c::visit(symbol);
+}
+
 /*  signed_integer DOTDOT signed_integer */
 /* dimension will be filled in during stage 3 (array_range_check_c) with the number of elements in this subrange */
 // SYM_REF2(subrange_c, lower_limit, upper_limit, unsigned long long int dimension)
@@ -267,8 +338,6 @@ void *array_range_check_c::visit(array_initial_elements_c *symbol) {
 	if (VALID_CVALUE( int64, symbol->integer) && (GET_CVALUE( int64, symbol->integer) < 0)) 
 		ERROR; /* the IEC 61131-3 syntax guarantees that this value will never be negative! */
 
-	/* TODO: check that the total number of 'initial values' does not exceed the size of the array! */
-
 	return NULL;
 }
 
@@ -343,6 +412,5 @@ void *array_range_check_c::visit(program_declaration_c *symbol) {
 	// search_var_instance_decl = NULL;
 	return NULL;
 }
-
 
 

--- a/stage3/array_range_check.hh
+++ b/stage3/array_range_check.hh
@@ -46,6 +46,8 @@ class array_range_check_c: public iterator_visitor_c {
 
     void check_dimension_count(array_variable_c *symbol);
     void check_bounds(array_variable_c *symbol);
+    unsigned long long int array_size(symbol_c *symbol);
+    unsigned long long int initialization_element_count(symbol_c *symbol);
 
   public:
     array_range_check_c(symbol_c *ignore);
@@ -63,6 +65,8 @@ class array_range_check_c: public iterator_visitor_c {
     /********************************/
     /* NOTE: we may later want to move the following 2 methods to a visitor that will focus on analysing the data type declarations! */
     void *visit(subrange_c *symbol);
+    void *visit(array_spec_init_c *symbol);
+    void *visit(array_initial_elements_list_c *symbol);
     void *visit(array_initial_elements_c *symbol);
   
     /*********************/
@@ -92,7 +96,6 @@ class array_range_check_c: public iterator_visitor_c {
     void *visit(program_declaration_c *symbol);
 
 }; /* array_range_check_c */
-
 
 
 

--- a/stage3/fill_candidate_datatypes.cc
+++ b/stage3/fill_candidate_datatypes.cc
@@ -1145,10 +1145,58 @@ void *fill_candidate_datatypes_c::visit(array_spec_init_c *symbol) {return fill_
 /* helper symbol for array_initialization */
 /* array_initial_elements_list ',' array_initial_elements */
 // SYM_LIST(array_initial_elements_list_c)
+void *fill_candidate_datatypes_c::visit(array_initial_elements_list_c *symbol) {
+	/* Run a bottom->up pass first, then retry non-elementary elements with the candidate array types inherited from the parent. */
+	iterator_visitor_c::visit(symbol);
+
+	for (unsigned int i = 0; i < symbol->parent->candidate_datatypes.size(); i++) {
+		symbol_c *array_type = symbol->parent->candidate_datatypes[i];
+		symbol_c *element_type = search_base_type_c::get_basetype_decl(get_datatype_info_c::get_array_storedtype_id(array_type));
+		int flag_all_elem_ok = 1;
+
+		if (!get_datatype_info_c::is_type_valid(element_type))
+			continue;
+
+		for (int k = 0; k < symbol->n; k++) {
+			symbol_c *init_elem = symbol->get_element(k);
+			array_initial_elements_c *array_elem = dynamic_cast<array_initial_elements_c *>(init_elem);
+			symbol_c *typed_elem = init_elem;
+
+			/* "N()" repeats the default initial value of the array element type, so there is no explicit value to type-check. */
+			if ((array_elem != NULL) && (array_elem->array_initial_element == NULL))
+				continue;
+
+			if (array_elem != NULL)
+				typed_elem = array_elem->array_initial_element;
+
+			if (!get_datatype_info_c::is_ANY_ELEMENTARY(element_type)) {
+				add_datatype_to_candidate_list(init_elem, element_type);
+				add_datatype_to_candidate_list(typed_elem, element_type);
+				init_elem->accept(*this);
+			}
+
+			if (search_in_candidate_datatype_list(element_type, init_elem->candidate_datatypes) < 0)
+				flag_all_elem_ok = 0;
+		}
+
+		if (flag_all_elem_ok)
+			add_datatype_to_candidate_list(symbol, array_type);
+	}
+
+	return NULL;
+}
 
 /* integer '(' [array_initial_element] ')' */
 /* array_initial_element may be NULL ! */
 // SYM_REF2(array_initial_elements_c, integer, array_initial_element)
+void *fill_candidate_datatypes_c::visit(array_initial_elements_c *symbol) {
+	if (symbol->array_initial_element == NULL)
+		return NULL;
+
+	symbol->array_initial_element->accept(*this);
+	symbol->candidate_datatypes = symbol->array_initial_element->candidate_datatypes;
+	return NULL;
+}
 
 /*  structure_type_name ':' structure_specification */
 // SYM_REF2(structure_type_declaration_c, structure_type_name, structure_specification)
@@ -2378,8 +2426,6 @@ void *fill_candidate_datatypes_c::visit(repeat_statement_c *symbol) {
 		symbol->statement_list->accept(*this);
 	return NULL;
 }
-
-
 
 
 

--- a/stage3/fill_candidate_datatypes.hh
+++ b/stage3/fill_candidate_datatypes.hh
@@ -205,8 +205,8 @@ class fill_candidate_datatypes_c: public iterator_visitor_c {
     void *visit(array_spec_init_c *symbol);
 //  void *visit(array_specification_c *symbol);     /* Not required. already handled by iterator_visitor_c base class */
 //  void *visit(array_subrange_list_c *symbol);
-//  void *visit(array_initial_elements_list_c *symbol);
-//  void *visit(array_initial_elements_c *symbol);
+    void *visit(array_initial_elements_list_c *symbol);
+    void *visit(array_initial_elements_c *symbol);
     void *visit(structure_type_declaration_c *symbol);
     void *visit(initialized_structure_c *symbol);
 //  void *visit(structure_element_declaration_list_c *symbol);
@@ -411,7 +411,6 @@ class fill_candidate_datatypes_c: public iterator_visitor_c {
     void *visit(repeat_statement_c *symbol);
 
 }; // fill_candidate_datatypes_c
-
 
 
 

--- a/stage3/lvalue_check.cc
+++ b/stage3/lvalue_check.cc
@@ -263,6 +263,19 @@ void lvalue_check_c::check_assignment_to_il_list(symbol_c *lvalue) {
 
 
 
+void *lvalue_check_c::visit(array_variable_c *symbol) {
+	/* Keep traversal of complex lvalues explicit so subscript expressions keep getting checked even if the base iterator changes. */
+	if (symbol->subscripted_variable != NULL) symbol->subscripted_variable->accept(*this);
+	if (symbol->subscript_list != NULL)       symbol->subscript_list->accept(*this);
+	return NULL;
+}
+
+void *lvalue_check_c::visit(structured_variable_c *symbol) {
+	if (symbol->record_variable != NULL) symbol->record_variable->accept(*this);
+	return NULL;
+}
+
+
 void lvalue_check_c::verify_is_lvalue(symbol_c *lvalue) {
 	if (NULL == lvalue) return; // missing operand in source code being compiled. Error will be caught and reported by datatype checking!
 	int init_error_count = error_count;  /* stop the checks once an error has been found... */
@@ -579,7 +592,6 @@ void *lvalue_check_c::visit(for_statement_c *symbol) {
 	control_variables.pop_back();
 	return NULL;
 }
-
 
 
 

--- a/stage3/lvalue_check.hh
+++ b/stage3/lvalue_check.hh
@@ -71,6 +71,12 @@ class lvalue_check_c: public iterator_visitor_c {
     virtual ~lvalue_check_c(void);
     int get_error_count();
 
+    /*********************/
+    /* B 1.4 - Variables */
+    /*********************/
+    void *visit(array_variable_c *symbol);
+    void *visit(structured_variable_c *symbol);
+
     /**************************************/
     /* B 1.5 - Program organisation units */
     /**************************************/
@@ -133,7 +139,6 @@ class lvalue_check_c: public iterator_visitor_c {
     void *visit(for_statement_c *symbol);
 
 }; /* lvalue_check_c */
-
 
 
 

--- a/stage3/narrow_candidate_datatypes.cc
+++ b/stage3/narrow_candidate_datatypes.cc
@@ -642,12 +642,35 @@ void *narrow_candidate_datatypes_c::visit(array_spec_init_c *symbol) {return nar
 /* helper symbol for array_initialization */
 /* array_initial_elements_list ',' array_initial_elements */
 // SYM_LIST(array_initial_elements_list_c)
-// Not needed ???
+void *narrow_candidate_datatypes_c::visit(array_initial_elements_list_c *symbol) {
+	symbol_c *array_type = symbol->datatype;
+	if (!get_datatype_info_c::is_type_valid(array_type))
+		array_type = symbol->parent->datatype;
+
+	if (get_datatype_info_c::is_type_valid(array_type)) {
+		symbol_c *element_type = search_base_type_c::get_basetype_decl(get_datatype_info_c::get_array_storedtype_id(array_type));
+		for (int i = 0; i < symbol->n; i++) {
+			symbol_c *init_elem = symbol->get_element(i);
+			array_initial_elements_c *array_elem = dynamic_cast<array_initial_elements_c *>(init_elem);
+			if ((array_elem != NULL) && (array_elem->array_initial_element == NULL))
+				continue;
+			set_datatype(element_type, init_elem);
+			init_elem->accept(*this);
+		}
+	}
+	return NULL;
+}
 
 /* integer '(' [array_initial_element] ')' */
 /* array_initial_element may be NULL ! */
 // SYM_REF2(array_initial_elements_c, integer, array_initial_element)
-// Not needed ???
+void *narrow_candidate_datatypes_c::visit(array_initial_elements_c *symbol) {
+	if (symbol->array_initial_element == NULL)
+		return NULL;
+	set_datatype(symbol->datatype, symbol->array_initial_element);
+	symbol->array_initial_element->accept(*this);
+	return NULL;
+}
 
 /*  structure_type_name ':' structure_specification */
 // SYM_REF2(structure_type_declaration_c, structure_type_name, structure_specification)
@@ -1857,8 +1880,6 @@ void *narrow_candidate_datatypes_c::visit(repeat_statement_c *symbol) {
 		symbol->statement_list->accept(*this);
 	return NULL;
 }
-
-
 
 
 

--- a/stage3/narrow_candidate_datatypes.hh
+++ b/stage3/narrow_candidate_datatypes.hh
@@ -183,8 +183,8 @@ class narrow_candidate_datatypes_c: public iterator_visitor_c {
     void *visit(array_spec_init_c *symbol);
 //  void *visit(array_specification_c *symbol);
 //  void *visit(array_subrange_list_c *symbol);
-//  void *visit(array_initial_elements_list_c *symbol);
-//  void *visit(array_initial_elements_c *symbol);
+    void *visit(array_initial_elements_list_c *symbol);
+    void *visit(array_initial_elements_c *symbol);
     void *visit(structure_type_declaration_c *symbol);
     void *visit(initialized_structure_c *symbol);
 //  void *visit(structure_element_declaration_list_c *symbol);
@@ -392,6 +392,5 @@ class narrow_candidate_datatypes_c: public iterator_visitor_c {
 
 
 #endif // #ifndef _NARROW_CANDIDATE_DATATYPES_HH
-
 
 

--- a/stage3/print_datatypes_error.cc
+++ b/stage3/print_datatypes_error.cc
@@ -544,6 +544,22 @@ void *print_datatypes_error_c::visit(enumerated_value_c *symbol) {
 	return NULL;
 }
 
+void *print_datatypes_error_c::visit(array_initial_elements_list_c *symbol) {
+	for (int i = 0; i < symbol->n; i++)
+		symbol->get_element(i)->accept(*this);
+	return NULL;
+}
+
+void *print_datatypes_error_c::visit(array_initial_elements_c *symbol) {
+	if (symbol->array_initial_element == NULL)
+		return NULL;
+
+	symbol->array_initial_element->accept(*this);
+	if (!get_datatype_info_c::is_type_valid(symbol->datatype))
+		STAGE3_ERROR(0, symbol, symbol, "Array initialization element has incompatible data type.");
+	return NULL;
+}
+
 
 
 void *print_datatypes_error_c::visit(structure_element_initialization_c *symbol) {
@@ -1295,8 +1311,6 @@ void *print_datatypes_error_c::visit(repeat_statement_c *symbol) {
 	symbol->expression->accept(*this);
 	return NULL;
 }
-
-
 
 
 

--- a/stage3/print_datatypes_error.hh
+++ b/stage3/print_datatypes_error.hh
@@ -161,6 +161,8 @@ class print_datatypes_error_c: public iterator_visitor_c {
     void *visit(simple_spec_init_c *symbol);
 //  void *visit(data_type_declaration_c *symbol); /* use base iterator_c method! */
     void *visit(enumerated_value_c *symbol);
+    void *visit(array_initial_elements_list_c *symbol);
+    void *visit(array_initial_elements_c *symbol);
 //  void *visit(structure_element_initialization_list_c *symbol);
     void *visit(structure_element_initialization_c *symbol);
 
@@ -341,7 +343,6 @@ class print_datatypes_error_c: public iterator_visitor_c {
     void *visit(repeat_statement_c *symbol);
 
 }; // print_datatypes_error_c
-
 
 
 

--- a/stage4/generate_c/generate_c_vardecl.cc
+++ b/stage4/generate_c/generate_c_vardecl.cc
@@ -241,16 +241,17 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
     /* array_initial_elements_list ',' array_initial_elements */
     void *visit(array_initial_elements_list_c *symbol) {
       switch (current_mode) {
-        case initializationvalue_am:
-          current_initialization_count = 0;
-          for (int i = 0; i < symbol->n; i++) {
-            if (current_initialization_count >= defined_values_count) {
-              if (defined_values_count >= array_size)
-                ERROR;
-              if (defined_values_count > 0)
-                s4o.print(",");
-              symbol->get_element(i)->accept(*this);
-              defined_values_count++;
+	        case initializationvalue_am:
+	          current_initialization_count = 0;
+	          for (int i = 0; i < symbol->n; i++) {
+	            if (current_initialization_count >= defined_values_count) {
+	              if (defined_values_count >= array_size)
+	                STAGE4_ERROR(symbol->get_element(i), symbol->get_element(i),
+	                             "Array initialization exceeds the array size declared in its type.");
+	              if (defined_values_count > 0)
+	                s4o.print(",");
+	              symbol->get_element(i)->accept(*this);
+	              defined_values_count++;
             }
             else {
               array_initial_elements_c *array_initial_element = dynamic_cast<array_initial_elements_c *>(symbol->get_element(i));
@@ -297,13 +298,14 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
               s4o.print(",");
             }
           }
-          else
-            current_initialization_count += initial_element_count - 1;
-          if (defined_values_count + initial_element_count > array_size)
-            ERROR;
-          for (unsigned long long int i = 0; i < initial_element_count; i++) {
-            if (i > 0)
-              s4o.print(",");
+	          else
+	            current_initialization_count += initial_element_count - 1;
+	          if (defined_values_count + initial_element_count > array_size)
+	            STAGE4_ERROR(symbol, symbol,
+	                         "Array initialization exceeds the array size declared in its type.");
+	          for (unsigned long long int i = 0; i < initial_element_count; i++) {
+	            if (i > 0)
+	              s4o.print(",");
             if (symbol->array_initial_element != NULL) {
               symbol->array_initial_element->accept(*this);
             }
@@ -2887,6 +2889,4 @@ SYM_REF2(fb_initialization_c, function_block_type_name, structure_initialization
 
 
 }; /* generate_c_vardecl_c */
-
-
 

--- a/stage4/generate_c/generate_c_vardecl.cc
+++ b/stage4/generate_c/generate_c_vardecl.cc
@@ -247,7 +247,7 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
 	            if (current_initialization_count >= defined_values_count) {
 	              if (defined_values_count >= array_size)
 	                STAGE4_ERROR(symbol->get_element(i), symbol->get_element(i),
-	                             "Array initialization exceeds the array size declared in its type.");
+	                             "Invalid array initialization encountered during C code generation.");
 	              if (defined_values_count > 0)
 	                s4o.print(",");
 	              symbol->get_element(i)->accept(*this);
@@ -302,7 +302,7 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
 	            current_initialization_count += initial_element_count - 1;
 	          if (defined_values_count + initial_element_count > array_size)
 	            STAGE4_ERROR(symbol, symbol,
-	                         "Array initialization exceeds the array size declared in its type.");
+	                         "Invalid array initialization encountered during C code generation.");
 	          for (unsigned long long int i = 0; i < initial_element_count; i++) {
 	            if (i > 0)
 	              s4o.print(",");
@@ -2889,4 +2889,3 @@ SYM_REF2(fb_initialization_c, function_block_type_name, structure_initialization
 
 
 }; /* generate_c_vardecl_c */
-


### PR DESCRIPTION
This PR fixes array initialization handling across semantic analysis and C code generation.

Before this change, some array initialization cases were not handled consistently in stage3, and invalid initializations could propagate to stage4 and end in an internal compiler error instead of a proper user-facing error.

Changes included:

add explicit stage3 handling for array initialization elements in fill, narrow, and error-reporting passes
propagate array element datatypes through nested and non-elementary initializers
make lvalue_check explicitly traverse structured and array variables
replace internal backend crashes in stage4 with a proper diagnostic when an array initialization exceeds the array size declared in its type
User-facing improvement:

invalid array initializations no longer fail with an internal compiler error in the tested path
stage4 now reports:
Array initialization exceeds the array size declared in its type.