### PR TITLE
Fix mixed signed array bound comparisons

### DIFF
--- a/stage3/array_range_check.cc
+++ b/stage3/array_range_check.cc
@@ -82,10 +82,15 @@
  *    first has a lesser value.
  */
 static inline int cmp_unsigned_signed(const uint64_t u, const int64_t s) {
-  const uint64_t INT64_MAX_uvar = INT64_MAX;
-  if (u <= INT64_MAX_uvar)
-    return ((int64_t)u - s);
-  return -1;
+  if (s < 0)
+    return 1;
+
+  const uint64_t unsigned_s = (uint64_t)s;
+  if (u < unsigned_s)
+    return -1;
+  if (u > unsigned_s)
+    return 1;
+  return 0;
 }
 
 array_range_check_c::array_range_check_c(symbol_c *ignore) {
@@ -383,6 +388,5 @@ void *array_range_check_c::visit(program_declaration_c *symbol) {
 	// search_var_instance_decl = NULL;
 	return NULL;
 }
-
 
 

--- a/tests/initialization/bad_array_unsigned_lower_bound.st
+++ b/tests/initialization/bad_array_unsigned_lower_bound.st
@@ -1,0 +1,21 @@
+(* A signed array index must compare correctly against an unsigned bound. *)
+
+TYPE
+  large_index_array : ARRAY [4294967296..4294967297] OF DINT;
+END_TYPE
+
+PROGRAM program0
+  VAR
+    values : large_index_array;
+    result : DINT;
+  END_VAR
+
+  result := values[0];
+END_PROGRAM
+
+CONFIGURATION config
+  RESOURCE resource1 ON PLC
+    TASK main_task(INTERVAL := T#1000ms, PRIORITY := 0);
+    PROGRAM instance0 WITH main_task : program0;
+  END_RESOURCE
+END_CONFIGURATION


### PR DESCRIPTION
## Summary

- compare unsigned array bounds with signed indices without narrowing or subtraction
- reject out-of-range signed indices when the declared bound is larger than `INT64_MAX` or `INT_MAX`
- add a regression case using an unsigned lower bound above 32 bits

## Validation

- `autoreconf -i`
- `./configure`
- `make -j2`
- `cd tests/initialization && ./runtests`

## Notes

- Validation ran in an Ubuntu 24.04 ARM64 container with GCC 13.3 and Bison 3.8.2.
