### PR TITLE
Fix nested array initialization generation

### DIFF
--- a/stage4/generate_c/generate_c_vardecl.cc
+++ b/stage4/generate_c/generate_c_vardecl.cc
@@ -81,6 +81,7 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
     unsigned long long int array_size;
     unsigned long long int defined_values_count;
     unsigned long long int current_initialization_count;
+    bool generating_array_initialization;
 
   public:
     generate_c_array_initialization_c(stage4out_c *s4o_ptr): generate_c_base_and_typeid_c(s4o_ptr) {}
@@ -90,6 +91,7 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
       array_size = 1;
       defined_values_count = 0;
       current_initialization_count = 0;
+      generating_array_initialization = false;
       array_base_type = array_default_value = array_default_initialization = NULL;
       
       current_mode = arraysize_am;
@@ -241,7 +243,15 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
     /* array_initial_elements_list ',' array_initial_elements */
     void *visit(array_initial_elements_list_c *symbol) {
       switch (current_mode) {
-        case initializationvalue_am:
+        case initializationvalue_am: {
+          if (generating_array_initialization) {
+            generate_c_array_initialization_c nested_array_initialization(&s4o);
+            nested_array_initialization.init_array_size(array_base_type);
+            nested_array_initialization.init_array_values(symbol);
+            break;
+          }
+
+          generating_array_initialization = true;
           current_initialization_count = 0;
           for (int i = 0; i < symbol->n; i++) {
             if (current_initialization_count >= defined_values_count) {
@@ -261,7 +271,9 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
             }
             current_initialization_count++;
           }
+          generating_array_initialization = false;
           break;
+        }
         default:
           break;
       }
@@ -2887,6 +2899,5 @@ SYM_REF2(fb_initialization_c, function_block_type_name, structure_initialization
 
 
 }; /* generate_c_vardecl_c */
-
 
 

--- a/tests/initialization/ok_array_nested.st
+++ b/tests/initialization/ok_array_nested.st
@@ -1,9 +1,4 @@
-(* Test of initial values for structured/array data types. *)
-
-(* KNOWN FAILURE: an array initialization nested inside another array initialization
- * aborts the C code generator (generate_c_vardecl.cc), as it counts the initial values
- * of every nesting level with the same set of counters.
- *)
+(* Test an array initialization nested inside another array initialization. *)
 
 TYPE
   arr_dint : ARRAY [1..2] OF DINT;

--- a/tests/initialization/runtests
+++ b/tests/initialization/runtests
@@ -20,7 +20,8 @@ error=0
 rm -rf $OUTDIR
 mkdir -p $OUTDIR
 
-for ff in `ls ok_*.st bad_*.st xfail_*.st`
+shopt -s nullglob
+for ff in ok_*.st bad_*.st xfail_*.st
 do
   rm -rf $OUTDIR/*
   $IEC2C $IEC2C_FLAGS -T $OUTDIR $ff > $ff.out 2> $ff.err


### PR DESCRIPTION
## Summary

- generate nested array initializers with an independent generator state for each nesting level
- prevent inner arrays from changing the outer array's element counters
- promote the existing nested-array XFAIL to a passing regression test
- make the initialization runner tolerate an empty `xfail_*.st` set

## Validation

- `make -j2`
- `cd tests/initialization && ./runtests`

## Notes

- Validation ran in an Ubuntu 24.04 ARM64 container with GCC 13.3 and Bison 3.8.2.
- The legacy `tests/build.sh` C compilation helper was also tried, but it is tied to the old `STD_CONF.c` and `STD_RESSOURCE.c` fixture names and cannot compile this configuration fixture.
