### PR TITLE
Reject multiple input files

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -225,7 +225,7 @@ int main(int argc, char **argv) {
     errflg++;
   }
 
-  if (optind > argc) {
+  if ((argc - optind) > 1) {
     fprintf(stderr, "Too many input files\n");
     errflg++;
   }
@@ -263,5 +263,4 @@ int main(int argc, char **argv) {
 
   return 0;
 }
-
 


### PR DESCRIPTION
## Summary

- detect when more than one positional input file remains after option parsing
- reject extra input files instead of silently compiling only the first one

## Validation

- `make -j2`
- `./iec2c tests/initialization/ok_array_scalar.st tests/initialization/ok_struct_enum.st` returns 1 and reports `Too many input files`
- `cd tests/initialization && ./runtests`

## Notes

- Validation ran in an Ubuntu 24.04 ARM64 container with GCC 13.3 and Bison 3.8.2.
