### PR TITLE
Reject empty include and target directories

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -192,13 +192,25 @@ int main(int argc, char **argv) {
        *       In this way compiler front-end accepts paths with or without
        *       slash terminator.
        */
-      path_len = strlen(optarg) - 1;
+      path_len = strlen(optarg);
+      if (path_len == 0) {
+        fprintf(stderr, "Option -I requires a non-empty directory\n");
+        errflg++;
+        break;
+      }
+      path_len--;
       if (optarg[path_len] == '\\') optarg[path_len]= '\0';
       runtime_options.includedir = optarg;
       break;
     case 'T':
       /* NOTE: see note above */
-      path_len = strlen(optarg) - 1;
+      path_len = strlen(optarg);
+      if (path_len == 0) {
+        fprintf(stderr, "Option -T requires a non-empty directory\n");
+        errflg++;
+        break;
+      }
+      path_len--;
       if (optarg[path_len] == '\\') optarg[path_len]= '\0';
       builddir = optarg;
       break;
@@ -263,5 +275,4 @@ int main(int argc, char **argv) {
 
   return 0;
 }
-
 


### PR DESCRIPTION
## Summary

- reject empty `-I` include-directory arguments before inspecting the final path character
- reject empty `-T` target-directory arguments before path normalization
- prevent out-of-bounds reads and unintended output paths rooted at `/`

## Validation

- `make -j2`
- `./iec2c -I '' tests/initialization/ok_array_scalar.st` returns 1 with a non-empty-directory diagnostic
- `./iec2c -T '' tests/initialization/ok_array_scalar.st` returns 1 with a non-empty-directory diagnostic
- `cd tests/initialization && ./runtests`

## Notes

- Validation ran in an Ubuntu 24.04 ARM64 container with GCC 13.3 and Bison 3.8.2.
