### PR TITLE
Report code generation write failures

### DIFF
--- a/stage4/stage4.cc
+++ b/stage4/stage4.cc
@@ -55,6 +55,8 @@
 #define  LAST_(symbol1, symbol2) (((symbol1)->last_order  > (symbol2)->last_order)    ? (symbol1) : (symbol2))
 #include <stdarg.h>
 
+bool stage4out_c::output_error = false;
+
 void stage4err(const char *stage4_generator_id, symbol_c *symbol1, symbol_c *symbol2, const char *errmsg, ...) {
     va_list argptr;
     va_start(argptr, errmsg); /* second argument is last fixed pamater of stage4err() */
@@ -108,13 +110,25 @@ stage4out_c::stage4out_c(const char *dir, const char *radix, const char *extensi
 stage4out_c::~stage4out_c(void) {
   if(m_file)
   {
+    m_file->flush();
+    if (m_file->fail()) output_error = true;
     m_file->close();
+    if (m_file->fail()) output_error = true;
     delete m_file;
   }
 }
 
 void stage4out_c::flush(void) {
   out->flush();
+  if (out->fail()) output_error = true;
+}
+
+void stage4out_c::reset_output_error(void) {
+  output_error = false;
+}
+
+bool stage4out_c::has_output_error(void) {
+  return output_error;
 }
 
 void stage4out_c::enable_output(void) {
@@ -256,6 +270,7 @@ void delete_code_generator(visitor_c *code_generator);
 
 
 int stage4(symbol_c *tree_root, const char *builddir) {
+  stage4out_c::reset_output_error();
   stage4out_c s4o;
   visitor_c *generate_code = new_code_generator(&s4o, builddir);
 
@@ -265,6 +280,11 @@ int stage4(symbol_c *tree_root, const char *builddir) {
 
   delete_code_generator(generate_code);
 
+  s4o.flush();
+  if (stage4out_c::has_output_error()) {
+    fprintf(stderr, "Error writing generated output.\n");
+    return -1;
+  }
+
   return 0;
 }
-

--- a/stage4/stage4.hh
+++ b/stage4/stage4.hh
@@ -56,6 +56,8 @@ class stage4out_c {
     ~stage4out_c(void);
     
     void flush(void);
+    static void reset_output_error(void);
+    static bool has_output_error(void);
     
     void enable_output(void);
     void disable_output(void);
@@ -97,6 +99,8 @@ class stage4out_c {
      * semantic analysers from analysing the code.
      */
     bool allow_output;
+
+    static bool output_error;
 
 };
 


### PR DESCRIPTION
## Summary

- track output stream failures across all stage 4 output files
- check stream state after flushing and closing generated files
- return a compiler failure when delayed writes cannot be persisted

## Validation

- `make -j2`
- generated `POUS.c` through a `/dev/full` symlink; `iec2c` returns 1 and reports `Error writing generated output.`
- `cd tests/initialization && ./runtests`

## Notes

- Validation ran in an Ubuntu 24.04 ARM64 container with GCC 13.3 and Bison 3.8.2.
