### PR TITLE
Reject constant function block instances

### DIFF
--- a/stage3/TODO
+++ b/stage3/TODO
@@ -6,8 +6,3 @@
 1) Handling of CONSTANTs:
 
  1.a) "Any program organization unit attempts to modify the value of a variable that has been declared with the CONSTANT qualifier;"
- 1.b) From table 16.a "The CONSTANT qualifier shall not be used in the declaration of function block instances as described in 2.5.2.1."
-
-
-
-

--- a/stage3/declaration_check.cc
+++ b/stage3/declaration_check.cc
@@ -218,6 +218,49 @@ int check_extern_c::error_count = 0;
 std::set<symbol_c *> check_extern_c::checked_decl;
 
 
+class constant_function_block_check_c: public iterator_visitor_c {
+  private:
+    int error_count;
+    int current_display_error_level;
+    bool declarations_are_constant;
+
+    void *check_declarations(symbol_c *option, symbol_c *declarations) {
+      bool previous_state = declarations_are_constant;
+      declarations_are_constant = (NULL != dynamic_cast<constant_option_c *>(option));
+      if (NULL != declarations) declarations->accept(*this);
+      declarations_are_constant = previous_state;
+      return NULL;
+    }
+
+  public:
+    constant_function_block_check_c(void) {
+      error_count = 0;
+      current_display_error_level = 0;
+      declarations_are_constant = false;
+    }
+
+    int get_error_count(void) {return error_count;}
+
+    void *visit(var_declarations_c *symbol) {
+      return check_declarations(symbol->option, symbol->var_init_decl_list);
+    }
+
+    void *visit(external_var_declarations_c *symbol) {
+      return check_declarations(symbol->option, symbol->external_declaration_list);
+    }
+
+    void *visit(global_var_declarations_c *symbol) {
+      return check_declarations(symbol->option, symbol->global_var_decl_list);
+    }
+
+    void *visit(fb_spec_init_c *symbol) {
+      if (declarations_are_constant)
+        STAGE3_ERROR(0, symbol, symbol, "Function block instances may not be declared CONSTANT.");
+      return NULL;
+    }
+};
+
+
 
 
 
@@ -230,7 +273,9 @@ declaration_check_c::declaration_check_c(symbol_c *ignore) {
   current_display_error_level = 0;
   current_pou_decl = NULL;
   current_resource_decl = NULL;
-  error_count = 0;
+  constant_function_block_check_c constant_function_block_check;
+  if (NULL != ignore) ignore->accept(constant_function_block_check);
+  error_count = constant_function_block_check.get_error_count();
 }
 
 declaration_check_c::~declaration_check_c(void) {
@@ -238,7 +283,7 @@ declaration_check_c::~declaration_check_c(void) {
 }
 
 int declaration_check_c::get_error_count() {
-  return check_extern_c::error_count;
+  return error_count + check_extern_c::error_count;
 }
 
 /*****************************/
@@ -317,4 +362,3 @@ void *declaration_check_c::visit(program_configuration_c *symbol) {
   p_decl->accept(check_extern);
   return NULL;
 }
-

--- a/tests/initialization/bad_constant_function_block.st
+++ b/tests/initialization/bad_constant_function_block.st
@@ -1,0 +1,24 @@
+(* Function block instances cannot be declared in a CONSTANT variable block. *)
+
+FUNCTION_BLOCK counter_fb
+  VAR
+    count : DINT;
+  END_VAR
+
+  count := count + 1;
+END_FUNCTION_BLOCK
+
+PROGRAM program0
+  VAR CONSTANT
+    counter : counter_fb;
+  END_VAR
+
+  counter();
+END_PROGRAM
+
+CONFIGURATION config
+  RESOURCE resource1 ON PLC
+    TASK main_task(INTERVAL := T#1000ms, PRIORITY := 0);
+    PROGRAM instance0 WITH main_task : program0;
+  END_RESOURCE
+END_CONFIGURATION

--- a/tests/initialization/ok_function_block_instance.st
+++ b/tests/initialization/ok_function_block_instance.st
@@ -1,0 +1,24 @@
+(* Function block instances remain valid in a non-CONSTANT variable block. *)
+
+FUNCTION_BLOCK counter_fb
+  VAR
+    count : DINT;
+  END_VAR
+
+  count := count + 1;
+END_FUNCTION_BLOCK
+
+PROGRAM program0
+  VAR
+    counter : counter_fb;
+  END_VAR
+
+  counter();
+END_PROGRAM
+
+CONFIGURATION config
+  RESOURCE resource1 ON PLC
+    TASK main_task(INTERVAL := T#1000ms, PRIORITY := 0);
+    PROGRAM instance0 WITH main_task : program0;
+  END_RESOURCE
+END_CONFIGURATION


### PR DESCRIPTION
## Summary

- add a declaration pass that tracks `CONSTANT` variable sections
- reject function block specifications found in constant local, external, or global declarations
- add both rejected constant-FB and accepted ordinary-FB regression cases
- remove the completed function-block item from the stage 3 TODO

## Validation

- `make -j2`
- `cd tests/initialization && ./runtests`
- `bad_constant_function_block.st` returns 1 with `Function block instances may not be declared CONSTANT.`

## Notes

- Validation ran in an Ubuntu 24.04 ARM64 container with GCC 13.3 and Bison 3.8.2.
